### PR TITLE
Fix missing tuple unpacking for CharacterCode in StreamAttributes

### DIFF
--- a/pyguymer3/media/MPLS/load_StreamAttributes.py
+++ b/pyguymer3/media/MPLS/load_StreamAttributes.py
@@ -27,7 +27,7 @@ def load_StreamAttributes(fObj, /):
         elif ans["StreamCodingType"] in [int(0x90), int(0x91)]:
             ans["LanguageCode"] = fObj.read(3).decode("utf-8")
         elif ans["StreamCodingType"] in [int(0x92)]:
-            ans["CharacterCode"] = struct.unpack(">B", fObj.read(1))
+            ans["CharacterCode"], = struct.unpack(">B", fObj.read(1))
             # NOTE: See https://github.com/lw/BluRay/wiki/StreamAttributes#charactercode
             if ans["CharacterCode"] in [int(0x01)]:
                 ans["LanguageCode"] = fObj.read(3).decode("utf-8")


### PR DESCRIPTION
Tuple unpacking is missing for StreamAttribute CharacterCode. Without this patch it compares something like "(1, ) in [1]". For StreamCodingType=0x92 it would always run into the else statement.